### PR TITLE
Make sure gtk+'s event loop is really exited, when user pressed Alt-F4.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -3,12 +3,15 @@
 #include <gtk/gtk.h>
 #include <GL/gl.h>
 
+static void destroy(GtkWidget* widget)
+{
+	gtk_main_quit();
+}
 
 static void setup(GtkGLArea *gl)
 {
 	gtk_gl_area_make_current(gl);
 }
-
 
 static gboolean render(GtkGLArea *gl, GdkGLContext *ctx)
 {
@@ -21,13 +24,13 @@ static gboolean render(GtkGLArea *gl, GdkGLContext *ctx)
 	return TRUE;
 }
 
-
 int main(void) {
 	/* skip one param, who needs it anyway */
 	((void (*)(int *))gtk_init)(NULL);
 
 	/* setup window */
 	GtkWidget *window = gtk_window_new(GTK_WINDOW_TOPLEVEL);
+	g_signal_connect(window, "destroy", G_CALLBACK(destroy), NULL);
 	GtkWidget *gl = gtk_gl_area_new();
 	gtk_container_add(GTK_CONTAINER(window), gl);
 	g_signal_connect(gl, "realize", G_CALLBACK(setup), NULL);


### PR DESCRIPTION
Here's a minor bug-fix for the demo app coming with the liner framework. Turns out when a user closes the program the window closes, but the event-loop still runs. This patch fixes it by connecting to the "destroy"-signal of the window and calling gtk_main_quit(), thus the process is really ended.